### PR TITLE
Add weekly Docker image cleanup

### DIFF
--- a/ansible/roles/cron/defaults/main.yml
+++ b/ansible/roles/cron/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+run_image_prune_min: 10
+run_image_prune_hour: 03
+run_image_prune_weekday: 0

--- a/ansible/roles/cron/tasks/main.yml
+++ b/ansible/roles/cron/tasks/main.yml
@@ -24,5 +24,14 @@
     job: "/usr/local/bin/docker-cleanup.sh {{ max_container_ttl }} {{ docker_stop_wait_time }}"
     state: present
 
+- name: Create cron job for weekly full Docker image cleanup
+  cron:
+    name: "docker-image-cleanup"
+    minute: "{{ run_image_prune_min }}"
+    hour: "{{ run_image_prune_hour }}"
+    weekday: "{{ run_image_prune_weekday }}"
+    job: "/usr/bin/docker image prune -a -f"
+    state: present
+
 - name: Clean DNF cache
   command: dnf clean all


### PR DESCRIPTION
Overtime images are building up resulting in failures due to space exhaustion.

Added a weekly cron job to clear all unused images, with defaults to schedule for 03:10 every Sunday.