### PR TITLE
set dir to something other than root

### DIFF
--- a/ansible/roles/chs_dev/tasks/main.yml
+++ b/ansible/roles/chs_dev/tasks/main.yml
@@ -12,7 +12,9 @@
     mode: '0755'
 
 - name: Install chs-dev
-  ansible.builtin.command: bash /tmp/install-chs-dev.sh -f -s /usr/local/bin -d /usr/local/lib/chs-dev
+  ansible.builtin.command: bash /tmp/install-chs-dev.sh -f -s /usr/local/bin
+  become: true
+  become_user: ec2-user
 
 - name: Remove chs-dev install script
   ansible.builtin.file:

--- a/ansible/roles/chs_dev/tasks/main.yml
+++ b/ansible/roles/chs_dev/tasks/main.yml
@@ -12,7 +12,7 @@
     mode: '0755'
 
 - name: Install chs-dev
-  ansible.builtin.command: bash /tmp/install-chs-dev.sh -f -s /usr/local/bin
+  ansible.builtin.command: bash /tmp/install-chs-dev.sh -f -s /usr/local/bin -d /usr/local/lib/chs-dev
 
 - name: Remove chs-dev install script
   ansible.builtin.file:

--- a/ansible/roles/chs_dev/tasks/main.yml
+++ b/ansible/roles/chs_dev/tasks/main.yml
@@ -12,9 +12,16 @@
     mode: '0755'
 
 - name: Install chs-dev
-  ansible.builtin.command: bash /tmp/install-chs-dev.sh -f -s /usr/local/bin
+  ansible.builtin.command: bash /tmp/install-chs-dev.sh -f -S
   become: true
   become_user: ec2-user
+
+- name: Link chs-dev into /usr/local/bin
+  ansible.builtin.file:
+    src: /home/ec2-user/.chs-dev/bin/chs-dev
+    dest: /usr/local/bin/chs-dev
+    state: link
+  become: true
 
 - name: Remove chs-dev install script
   ansible.builtin.file:


### PR DESCRIPTION
Installs chs-dev as `ec2-user` using `-S` to skip symlink creation, then manually create the symlink in `/usr/local/bin` as root so chs-dev is accessible to all users 