### PR TITLE
install and configure ecr cred helper

### DIFF
--- a/ansible/roles/docker/files/docker-config.json
+++ b/ansible/roles/docker/files/docker-config.json
@@ -1,0 +1,3 @@
+{
+  "credsStore": "ecr-login"
+}

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -43,7 +43,28 @@
     groups: docker
     append: true
 
-- name: service docker
+- name: Install amazon-ecr-credential-helper
+  ansible.builtin.dnf:
+    name: amazon-ecr-credential-helper
+    state: latest
+
+- name: Create .docker directory for ec2-user
+  ansible.builtin.file:
+    path: /home/ec2-user/.docker
+    state: directory
+    owner: ec2-user
+    group: ec2-user
+    mode: '0700'
+
+- name: Configure ECR credential helper
+  ansible.builtin.copy:
+    src: docker-config.json
+    dest: /home/ec2-user/.docker/config.json
+    owner: ec2-user
+    group: ec2-user
+    mode: '0600'
+
+- name: Start and enable docker service
   ansible.builtin.service:
     name: docker
     state: started


### PR DESCRIPTION
Add ECR credential helper to the ami
installs amazon-ecr-credential-helper and configures Docker to use it via credsStore
So should be able to authenticate with ecr via the iam role
Saves us passing credentials in the pipeline task