### PR TITLE
add new installs and config for buildx,compose and mvn settings

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -7,3 +7,4 @@
     - docker
     - chs_dev
     - cron
+    - maven

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -48,6 +48,22 @@
     name: amazon-ecr-credential-helper
     state: latest
 
+- name: Create .docker directory for root
+  ansible.builtin.file:
+    path: /root/.docker
+    state: directory
+    owner: root
+    group: root
+    mode: '0700'
+
+- name: Configure ECR credential helper for root
+  ansible.builtin.copy:
+    src: docker-config.json
+    dest: /root/.docker/config.json
+    owner: root
+    group: root
+    mode: '0600'
+
 - name: Create .docker directory for ec2-user
   ansible.builtin.file:
     path: /home/ec2-user/.docker

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -64,6 +64,34 @@
     group: ec2-user
     mode: '0600'
 
+- name: Create Docker CLI plugins directory
+  ansible.builtin.file:
+    path: /usr/libexec/docker/cli-plugins
+    state: directory
+    mode: '0755'
+
+- name: Get latest Docker Buildx version
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/docker/buildx/releases/latest
+  register: buildx_release
+
+- name: Install latest Docker Buildx
+  ansible.builtin.get_url:
+    url: "https://github.com/docker/buildx/releases/download/{{ buildx_release.json.tag_name }}/buildx-{{ buildx_release.json.tag_name }}.linux-amd64"
+    dest: /usr/libexec/docker/cli-plugins/docker-buildx
+    mode: '0755'
+
+- name: Get latest Docker Compose version
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/docker/compose/releases/latest
+  register: compose_release
+
+- name: Install latest Docker Compose
+  ansible.builtin.get_url:
+    url: "https://github.com/docker/compose/releases/download/{{ compose_release.json.tag_name }}/docker-compose-linux-x86_64"
+    dest: /usr/libexec/docker/cli-plugins/docker-compose
+    mode: '0755'
+
 - name: Start and enable docker service
   ansible.builtin.service:
     name: docker

--- a/ansible/roles/maven/files/settings.xml
+++ b/ansible/roles/maven/files/settings.xml
@@ -1,0 +1,20 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>virtual-release</id>
+      <name></name>
+      <url>https://chartifacts.jfrog.io/artifactory/virtual-release</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+  <servers>
+    <server>
+      <id>virtual-release</id>
+      <username>${ARTIFACTORY_USERNAME}</username>
+      <password>${ARTIFACTORY_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/ansible/roles/maven/tasks/main.yml
+++ b/ansible/roles/maven/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Create .m2 directory for ec2-user
+  ansible.builtin.file:
+    path: /home/ec2-user/.m2
+    state: directory
+    owner: ec2-user
+    group: ec2-user
+    mode: '0755'
+
+- name: Copy Maven settings.xml
+  ansible.builtin.copy:
+    src: settings.xml
+    dest: /home/ec2-user/.m2/settings.xml
+    owner: ec2-user
+    group: ec2-user
+    mode: '0600'


### PR DESCRIPTION
- Docker Compose: not included in AL2023 docker package, manually installed previously. 
- Docker Buildx: AL2023 ships with an older bundled version, manually installed previously. Using GitHub api to download the latest version each build.
- ECR credential helper:  helper was configured for ec2-user only, now added for root to see if this fixes authentication error
- Settings.xml: new maven role bakes the settings file into the AMI. Needed for services that pull dependencies down from artifactory