### PR TITLE
add aws_profile to bash file

### DIFF
--- a/ansible/roles/aws/tasks/main.yml
+++ b/ansible/roles/aws/tasks/main.yml
@@ -14,6 +14,12 @@
     group: ec2-user
     mode: '0600'
 
+- name: Set AWS_PROFILE in bash
+  ansible.builtin.lineinfile:
+    path: /home/ec2-user/.bashrc
+    line: 'export AWS_PROFILE=development-eu-west-2'
+    state: present
+
 - name: Install amazon-ecr-credential-helper
   ansible.builtin.dnf:
     name: amazon-ecr-credential-helper


### PR DESCRIPTION
Set AWS_PROFILE for chs-dev compatibility

- Adds AWS_PROFILE=development-eu-west-2 to ~/.bashrc so chs-dev can find a profile otherwise it falls over.

- On the EC2 there is no real profile, the chain falls through to the imdsv2 and IAM for credentials